### PR TITLE
fix: Ensure write metadata lock is released

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1429,14 +1429,14 @@ class ThresholdKey implements ITKey {
         privKey: this._localMetadataTransitions[0],
         serviceProvider: this.serviceProvider,
       });
+      this._localMetadataTransitions = [[], []];
+      this.lastFetchedCloudMetadata = this.metadata.clone();
     } catch (error: unknown) {
       throw CoreError.metadataPostFailed(prettyPrintError(error as Error));
+    } finally {
+      // release lock
+      if (acquiredLock) await this.releaseWriteMetadataLock();
     }
-
-    this._localMetadataTransitions = [[], []];
-    this.lastFetchedCloudMetadata = this.metadata.clone();
-    // release lock
-    if (acquiredLock) await this.releaseWriteMetadataLock();
   }
 
   // Returns a new instance of metadata with a clean state. All the previous state will be reset.


### PR DESCRIPTION
### Description
- Current `syncLocalMetadataTransitions` doesn't release the write metadata lock if an error were to occur.
- Adding a `finally` block will ensure the lock will always be released